### PR TITLE
fix: correct metrics module defects and document actual repo layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage
+htmlcov/
+.venv/
+venv/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,10 +9,12 @@ This repository serves as the central hub for zero-0002's professional identity 
 ```
 zero-0002/
 ├── .github/
-│   └── workflows/          # GitHub Actions CI/CD pipelines
+│   └── workflows/          # GitHub Actions pipelines
 ├── assets/                 # Visual assets and SVG graphics
-├── docs/                   # Comprehensive documentation
 ├── tests/                  # Test suite for quality assurance
+├── drive_response_manager.py  # Engagement/response metrics
+├── pace_tracker.py            # Commit pace and release metrics
+├── performance_optimizer.py   # Caching and profiling helpers
 ├── CONTRIBUTING.md         # Contribution guidelines
 ├── ARCHITECTURE.md         # This file
 └── readme.md              # Main profile README
@@ -26,14 +28,13 @@ zero-0002/
 - Theme-specific media for light/dark modes
 
 #### Workflows (`.github/workflows/`)
-- **ci.yml**: Continuous integration pipeline
-  - Runs tests on every push and pull request
-  - Performs code linting and formatting checks
-  - Maintains code quality standards
-  - Uploads coverage reports
+- **pacman.yml**: Contribution-graph generation
+  - Runs on a daily schedule, on manual dispatch, and on pushes to `main`
+  - Generates the bomberman contribution graph SVGs
+  - Publishes the result to the `output` branch
 
 #### Documentation
-- **README.md**: Profile overview and quick links
+- **readme.md**: Profile overview and quick links
 - **CONTRIBUTING.md**: Guidelines for contributors
 - **ARCHITECTURE.md**: Technical design documentation
 
@@ -54,10 +55,9 @@ zero-0002/
 
 ### Quality Assurance
 
-- Linting: flake8 for Python code quality
-- Formatting: black for consistent code style
-- Testing: pytest for comprehensive test coverage
-- Coverage tracking: codecov integration
+- Testing: pytest suite under `tests/`, run locally with `python -m pytest tests/`
+- Repository structure and documentation are validated by `tests/test_repository.py`
+- Module behaviour is covered by `tests/test_modules.py`
 
 ## Development Guidelines
 

--- a/drive_response_manager.py
+++ b/drive_response_manager.py
@@ -36,7 +36,6 @@ class Response:
         delta = self.responded_at - self.created_at
         return delta.total_seconds() / 3600
     
-    @property
     def is_overdue(self, sla_hours: int = 24) -> bool:
         """Check if response is overdue based on SLA."""
         if self.responded_at:

--- a/pace_tracker.py
+++ b/pace_tracker.py
@@ -4,7 +4,7 @@ Monitors development velocity and packaging metrics.
 """
 
 import datetime
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 from dataclasses import dataclass
 
 
@@ -23,18 +23,24 @@ class CommitPaceTracker:
     def __init__(self):
         self.commits: List[CommitMetric] = []
         self.weekly_stats: Dict[int, int] = {}
+        self._by_date: Dict[datetime.date, CommitMetric] = {}
     
     def add_commit(self, date: datetime.date, message: str) -> None:
         """Add a commit entry."""
-        if not self.commits or self.commits[-1].date != date:
-            self.commits.append(CommitMetric(
+        # Look up by date rather than only comparing the last entry, so commits
+        # supplied out of chronological order still collapse into one day.
+        existing = self._by_date.get(date)
+        if existing is None:
+            metric = CommitMetric(
                 date=date,
                 count=1,
                 authors=1,
                 message_length=len(message)
-            ))
+            )
+            self._by_date[date] = metric
+            self.commits.append(metric)
         else:
-            self.commits[-1].count += 1
+            existing.count += 1
     
     def get_weekly_pace(self) -> Dict[str, float]:
         """Calculate weekly commit pace."""
@@ -43,8 +49,11 @@ class CommitPaceTracker:
         
         weekly_commits = {}
         for commit in self.commits:
-            week = commit.date.isocalendar()[1]
-            weekly_commits[f"week_{week}"] = weekly_commits.get(f"week_{week}", 0) + commit.count
+            iso_year, week, _ = commit.date.isocalendar()
+            # Include the ISO year so the same week number in different years
+            # does not collapse into a single bucket.
+            key = f"{iso_year}-W{week:02d}"
+            weekly_commits[key] = weekly_commits.get(key, 0) + commit.count
         
         return weekly_commits
     
@@ -85,18 +94,18 @@ class ReleaseManager:
         if len(self.releases) < 2:
             return 0.0
         
-        first_date = self.releases[0][1]
-        last_date = self.releases[-1][1]
-        days_between = (last_date - first_date).days
+        # Releases are not guaranteed to be recorded in chronological order.
+        dates = sorted(date for _, date in self.releases)
+        days_between = (dates[-1] - dates[0]).days
         months = days_between / 30.0
         
         return len(self.releases) / months if months > 0 else 0.0
     
-    def get_release_report(self) -> Dict[str, any]:
+    def get_release_report(self) -> Dict[str, Any]:
         """Generate release report."""
         return {
             'total_releases': len(self.releases),
-            'latest_release': self.releases[-1] if self.releases else None,
+            'latest_release': max(self.releases, key=lambda r: r[1]) if self.releases else None,
             'frequency_per_month': self.get_release_frequency(),
             'release_history': self.releases
         }
@@ -117,7 +126,7 @@ class PackageMetrics:
             'timestamp': datetime.datetime.now()
         })
     
-    def get_package_stats(self) -> Dict[str, any]:
+    def get_package_stats(self) -> Dict[str, Any]:
         """Get package statistics."""
         if not self.packages:
             return {}

--- a/performance_optimizer.py
+++ b/performance_optimizer.py
@@ -5,7 +5,7 @@ Implements caching and efficient algorithms to improve execution speed.
 
 import functools
 import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict
 
 
 class PerformanceMonitor:
@@ -41,6 +41,13 @@ class PerformanceMonitor:
         }
 
 
+# Global performance monitor, shared by every profiled function.
+_perf_monitor = PerformanceMonitor()
+
+# Upper bound on memoize caches so long-running processes cannot grow without limit.
+MEMOIZE_MAXSIZE = 128
+
+
 def memoize(func: Callable) -> Callable:
     """Decorator to cache function results."""
     cache: Dict[Any, Any] = {}
@@ -48,16 +55,23 @@ def memoize(func: Callable) -> Callable:
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         key = (args, tuple(sorted(kwargs.items())))
+        try:
+            hash(key)
+        except TypeError:
+            # Unhashable arguments cannot be cached; still return a correct result.
+            return func(*args, **kwargs)
         if key not in cache:
+            if len(cache) >= MEMOIZE_MAXSIZE:
+                cache.pop(next(iter(cache)))
             cache[key] = func(*args, **kwargs)
         return cache[key]
     
+    wrapper.cache = cache  # type: ignore
     return wrapper
 
 
 def profile_execution(func: Callable) -> Callable:
     """Decorator to profile function execution time."""
-    monitor = PerformanceMonitor()
     
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -67,9 +81,9 @@ def profile_execution(func: Callable) -> Callable:
             return result
         finally:
             duration = time.perf_counter() - start_time
-            monitor.record_execution(func.__name__, duration)
+            _perf_monitor.record_execution(func.__name__, duration)
     
-    wrapper.monitor = monitor  # type: ignore
+    wrapper.monitor = _perf_monitor  # type: ignore
     return wrapper
 
 
@@ -87,10 +101,6 @@ class OptimizedOperations:
         """Process items in batches for better performance."""
         for i in range(0, len(items), batch_size):
             yield items[i:i + batch_size]
-
-
-# Global performance monitor
-_perf_monitor = PerformanceMonitor()
 
 
 def get_performance_report() -> Dict[str, Any]:

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 </picture>
 
 ###
-<h2 align="center">Profile View</h1>
+<h2 align="center">Profile View</h2>
 <div align="center">
   <img src="https://count.getloli.com/@:RikuSato0?theme=booru-helltaker&padding=7&scale=1&align=top&pixelated=1&darkmode=auto"  />
 </div>

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,161 @@
+"""
+Regression tests for the metrics modules.
+
+Each test here pins behaviour that was previously broken, so the bugs cannot
+silently return.
+"""
+
+import datetime
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from drive_response_manager import EngagementMetrics, Response  # noqa: E402
+from pace_tracker import CommitPaceTracker, ReleaseManager  # noqa: E402
+from performance_optimizer import (  # noqa: E402
+    MEMOIZE_MAXSIZE,
+    OptimizedOperations,
+    get_performance_report,
+    memoize,
+    profile_execution,
+)
+
+
+def _response(hours_old, response_id="r1"):
+    created = datetime.datetime.now() - datetime.timedelta(hours=hours_old)
+    return Response(id=response_id, type="issue", created_at=created)
+
+
+class TestResponseOverdue:
+    """Response.is_overdue must be callable with an SLA override."""
+
+    def test_overdue_accepts_sla_argument(self):
+        metrics = EngagementMetrics()
+        metrics.add_response(_response(50))
+        assert len(metrics.get_overdue_items(24)) == 1
+
+    def test_not_overdue_within_sla(self):
+        metrics = EngagementMetrics()
+        metrics.add_response(_response(1))
+        assert metrics.get_overdue_items(24) == []
+
+    def test_custom_sla_is_respected(self):
+        metrics = EngagementMetrics()
+        metrics.add_response(_response(30))
+        assert metrics.get_overdue_items(48) == []
+        assert len(metrics.get_overdue_items(24)) == 1
+
+
+class TestCommitPaceTracker:
+    """Commits must aggregate per calendar day regardless of insert order."""
+
+    def test_same_date_added_out_of_order_is_one_entry(self):
+        tracker = CommitPaceTracker()
+        day_one = datetime.date(2026, 1, 1)
+        day_two = datetime.date(2026, 1, 2)
+        tracker.add_commit(day_one, "a")
+        tracker.add_commit(day_two, "b")
+        tracker.add_commit(day_one, "c")
+
+        assert len(tracker.commits) == 2
+        assert tracker.calculate_average_pace() == 1.5
+
+    def test_weekly_pace_separates_same_week_of_different_years(self):
+        tracker = CommitPaceTracker()
+        tracker.add_commit(datetime.date(2025, 1, 2), "a")
+        tracker.add_commit(datetime.date(2026, 1, 2), "b")
+
+        weekly = tracker.get_weekly_pace()
+        assert len(weekly) == 2
+        assert all(count == 1 for count in weekly.values())
+
+    def test_empty_tracker_returns_zero_pace(self):
+        assert CommitPaceTracker().calculate_average_pace() == 0.0
+
+
+class TestReleaseManager:
+    """Release frequency must not depend on insertion order."""
+
+    def test_frequency_with_out_of_order_releases(self):
+        manager = ReleaseManager()
+        manager.add_release("v2", datetime.date(2026, 6, 1))
+        manager.add_release("v1", datetime.date(2026, 1, 1))
+
+        assert manager.get_release_frequency() > 0
+
+    def test_frequency_matches_chronological_order(self):
+        ordered = ReleaseManager()
+        ordered.add_release("v1", datetime.date(2026, 1, 1))
+        ordered.add_release("v2", datetime.date(2026, 6, 1))
+
+        shuffled = ReleaseManager()
+        shuffled.add_release("v2", datetime.date(2026, 6, 1))
+        shuffled.add_release("v1", datetime.date(2026, 1, 1))
+
+        assert ordered.get_release_frequency() == shuffled.get_release_frequency()
+
+    def test_latest_release_is_newest_by_date(self):
+        manager = ReleaseManager()
+        manager.add_release("v2", datetime.date(2026, 6, 1))
+        manager.add_release("v1", datetime.date(2026, 1, 1))
+
+        assert manager.get_release_report()["latest_release"][0] == "v2"
+
+
+class TestPerformanceOptimizer:
+    """Profiling must feed the module-level report."""
+
+    def test_profiled_function_appears_in_global_report(self):
+        @profile_execution
+        def sample_workload():
+            return sum(range(100))
+
+        sample_workload()
+        sample_workload()
+
+        report = get_performance_report()
+        assert "sample_workload" in report
+        assert report["sample_workload"]["call_count"] == 2
+
+    def test_memoize_handles_unhashable_arguments(self):
+        calls = []
+
+        @memoize
+        def length_of(items):
+            calls.append(items)
+            return len(items)
+
+        assert length_of([1, 2, 3]) == 3
+        assert len(calls) == 1
+
+    def test_memoize_caches_hashable_arguments(self):
+        calls = []
+
+        @memoize
+        def double(value):
+            calls.append(value)
+            return value * 2
+
+        assert double(2) == 4
+        assert double(2) == 4
+        assert len(calls) == 1
+
+    def test_memoize_cache_is_bounded(self):
+        @memoize
+        def identity(value):
+            return value
+
+        for value in range(MEMOIZE_MAXSIZE + 50):
+            identity(value)
+
+        assert len(identity.cache) <= MEMOIZE_MAXSIZE
+
+    def test_compute_hash_is_stable(self):
+        first = OptimizedOperations.compute_hash("abc")
+        second = OptimizedOperations.compute_hash("abc")
+        assert first == second
+
+    def test_batch_process_splits_items(self):
+        batches = list(OptimizedOperations.batch_process(list(range(10)), batch_size=4))
+        assert [len(batch) for batch in batches] == [4, 4, 2]


### PR DESCRIPTION
## Summary
Fixes four confirmed runtime/correctness bugs in the metrics modules, plus two documentation inaccuracies. Every defect was reproduced against the current code before being changed.

## Confirmed bugs fixed

**1. `drive_response_manager.py` — `TypeError` on every overdue lookup**
`Response.is_overdue` was declared `@property` but takes `sla_hours`. `EngagementMetrics.get_overdue_items()` calls `r.is_overdue(sla_hours)`, so the property evaluates to a `bool` and is then called.

Reproduced: `TypeError: 'bool' object is not callable`. This also means `DriveManager.get_drive_report()` crashed, since it calls `get_overdue_items()`.

**2. `performance_optimizer.py` — `get_performance_report()` always returned `{}`**
`profile_execution` built a fresh `PerformanceMonitor()` per decorated function, never the module-level `_perf_monitor` that `get_performance_report()` reads. The module public reporting API was permanently empty.

**3. `performance_optimizer.py` — `memoize` crashed on unhashable args and was unbounded**
`OptimizedOperations.compute_hash(['a'])` raised `TypeError: cannot use 'tuple' as a dict key`. The cache also had no eviction, so long-running processes leaked memory.

**4. `pace_tracker.py` — three aggregation bugs**
- `add_commit` only compared against `commits[-1]`, so the same date supplied out of order created duplicate entries and skewed `calculate_average_pace` (2 distinct days produced 3 entries, pace `1.0` instead of `1.5`).
- `get_weekly_pace` keyed on week number alone, so 2025-W01 and 2026-W01 merged into one `week_1` bucket.
- `get_release_frequency` assumed insertion order was chronological; out-of-order releases gave a negative interval and silently returned `0.0`.
- `Dict[str, any]` used the builtin `any` function instead of `typing.Any`.

## Documentation
- `readme.md`: Profile View heading opened `<h2>` and closed `</h1>`.
- `ARCHITECTURE.md`: documented a `docs/` directory and a `ci.yml` workflow that do not exist, plus flake8/black/codecov tooling that is not configured. Updated to describe the actual layout and `pacman.yml`.

## Tests
Adds `tests/test_modules.py` with regression coverage for each fix.

```
27 passed in 2.86s
```

Also adds `.gitignore` so `__pycache__` artifacts are not committed.

Closes #343
Closes #344
Closes #345